### PR TITLE
Keep the .well-known folder accessible

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -249,11 +249,9 @@ AddDefaultCharset utf-8
 # But keep the .well-known folder: https://tools.ietf.org/html/rfc5785
 
 <IfModule mod_rewrite.c>
-    RewriteCond %{SCRIPT_FILENAME} ^\.well-known/.*
-    RewriteRule .* - [S=1]
-
     RewriteCond %{SCRIPT_FILENAME} -d [OR]
     RewriteCond %{SCRIPT_FILENAME} -f
+    RewriteCond %{REQUEST_URI} !^/\.well-known/
     RewriteRule "(^|/)\." - [F]
 </IfModule>
 

--- a/.htaccess
+++ b/.htaccess
@@ -246,8 +246,12 @@ AddDefaultCharset utf-8
 
 # Block access to hidden files and directories.
 # This includes directories used by version control systems such as Git and SVN.
+# But keep the .well-known folder: https://tools.ietf.org/html/rfc5785
 
 <IfModule mod_rewrite.c>
+    RewriteCond %{SCRIPT_FILENAME} ^\.well-known/.*
+    RewriteRule .* - [S=1]
+
     RewriteCond %{SCRIPT_FILENAME} -d [OR]
     RewriteCond %{SCRIPT_FILENAME} -f
     RewriteRule "(^|/)\." - [F]


### PR DESCRIPTION
The files in the .well-known folder must be accessible: https://tools.ietf.org/html/rfc5785